### PR TITLE
fix: set public address to local IP

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,11 @@ runs:
       addr="$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')"
       cat << EOF | sudo anbox-cloud-appliance init --preseed
       network:
+        # We set both listen and public address to the same local IP address
+        # as otherwise the appliance will attempt to determine the public
+        # address through the use of STUN.
         listen-address: $addr
+        public-address: $addr
       lxd:
         # We use 30GB here which should give us enough space
         storage-size: 32212254720


### PR DESCRIPTION
If we don't set the public address in the preseed, the appliance will try to determine it by sending a STUN request and check what public IP the machine sits behind. For the Github runners this isn't going to work as they are not forwarding any ports from their egress address back to the runner. Therefor we simply set the public address to the local IP we also configure as listen address. This will make any local streaming use case work.