### PR TITLE
feat: use latest Ubuntu 24.04

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   smoke:
     name: Minimal smoke tests for the action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
     - name: Setup Anbox Cloud

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ name: Run integration tests
 on: push
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Setup Anbox Cloud
       uses: canonical/anbox-cloud-github-action@main


### PR DESCRIPTION
The "ubuntu-latest" alias still points to 22.04 but we already are ready ot use the newer 24.04 at this point, so recommend that as the version to use.