### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/cache-images.yaml
+++ b/.github/workflows/cache-images.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 10 * * *'
 
+
+permissions:
+  contents: read
+
 jobs:
   cache-images:
     name: Cache Anbox Cloud images

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,10 @@
 name: Test action
 on: [push, pull_request, workflow_dispatch]
 
+
+permissions:
+  contents: read
+
 jobs:
   smoke:
     name: Minimal smoke tests for the action


### PR DESCRIPTION
Small CI hardening: declares an explicit workflow-level `permissions: contents: read` on 2 workflow(s) that currently inherit the default broad read-write GITHUB_TOKEN.

I inspected each file before including it; none publish, push, comment on issues/PRs, or otherwise write via the GitHub API, so the read-only default does not change behavior. Workflows that need to write (stale, release, gh-pages-deploy, publish actions, etc.) are intentionally left out of this PR.

This is the post-CVE-2025-30066 hardening pattern for default token scope.